### PR TITLE
Support cxx stubs

### DIFF
--- a/dune-compiledb.opam
+++ b/dune-compiledb.opam
@@ -14,7 +14,7 @@ depends: [
   "ezjsonm" {>= "1.0.0"}
   "sexplib"
   "sexplib0"
-  "fpath"
+  "fpath" {>= "0.7.1"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -18,6 +18,6 @@
   (ezjsonm (>= 1.0.0))
   sexplib
   sexplib0
-  fpath
+  (fpath (>= 0.7.1))
  )
 )

--- a/src/main.ml
+++ b/src/main.ml
@@ -234,7 +234,8 @@ module CompileCommand = struct
   let of_rule ~source_map rule =
     match rule with
     | Rule.{action= Action.(ChdirRun {dir; run= cmd :: args}); targets; deps} ->
-        let+ c_file = List.find_opt (Fpath.has_ext "c") deps
+        let+ c_file =
+          List.find_opt (Fpath.mem_ext ["c"; "cpp"; "cc"; "cxx"]) deps
         and+ _output = List.find_opt (Fpath.has_ext "o") targets in
         let file =
           Fpath.Map.find_opt c_file source_map |> Option.value ~default:c_file


### PR DESCRIPTION
I was attempting to use `dune-compiledb` while working on a library with foreign stubs written in C++ and noticed that c++ files were filtered out when attempting to create a compile_commands stanza from dune rules. Testing this diff locally seems to output a valid compile_commands, and I was able to use the resulting compile commands with clangd.