### PR TITLE
Add support for outputting in specific directory

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -25,12 +25,16 @@
 open Sexplib
 
 let debug = ref false
+let output_directory = ref ""
 
 let () =
   let usage_msg =
-    Printf.sprintf "Usage: dune rules | %s [-d]" Sys.executable_name
+    Printf.sprintf "Usage: dune rules | %s [-d] [-o directory]" Sys.executable_name
   in
-  let speclist = [("-d", Arg.Set debug, "Enable debug output")] in
+  let speclist = [
+    ("-d", Arg.Set debug, "Enable debug output");
+    ("-o", Arg.Set_string output_directory, "Output directory for compile_commands.json")
+  ] in
   Arg.parse speclist ignore usage_msg
 
 (* Applicative syntactic sugar for {!module:Option}. *)
@@ -270,7 +274,9 @@ let parse_rules_from_stdin () =
   stdin |> Sexp.input_rev_sexps |> List.filter_map Rule.of_sexp
 
 let with_output f =
-  let json = open_out "compile_commands.json" in
+  let outfile_name = Filename.concat !output_directory "compile_commands.json" in
+  if !debug then Format.eprintf "Saving to file %s" outfile_name;
+  let json = open_out outfile_name in
   Fun.protect ~finally:(fun () -> close_out json) (fun () -> f json)
 
 let () =

--- a/src/main.ml
+++ b/src/main.ml
@@ -25,16 +25,23 @@
 open Sexplib
 
 let debug = ref false
+
 let output_directory = ref ""
 
 let () =
   let usage_msg =
-    Printf.sprintf "Usage: dune rules | %s [-d] [-o directory]" Sys.executable_name
+    Printf.sprintf "Usage: dune rules | %s [-d] [-o directory]"
+      Sys.executable_name
   in
-  let speclist = [
-    ("-d", Arg.Set debug, "Enable debug output");
-    ("-o", Arg.Set_string output_directory, "Output directory for compile_commands.json")
-  ] in
+  let speclist =
+    [
+      ("-d", Arg.Set debug, "Enable debug output")
+    ; ( "-o"
+      , Arg.Set_string output_directory
+      , "Output directory for compile_commands.json"
+      )
+    ]
+  in
   Arg.parse speclist ignore usage_msg
 
 (* Applicative syntactic sugar for {!module:Option}. *)
@@ -274,8 +281,10 @@ let parse_rules_from_stdin () =
   stdin |> Sexp.input_rev_sexps |> List.filter_map Rule.of_sexp
 
 let with_output f =
-  let outfile_name = Filename.concat !output_directory "compile_commands.json" in
-  if !debug then Format.eprintf "Saving to file %s" outfile_name;
+  let outfile_name =
+    Filename.concat !output_directory "compile_commands.json"
+  in
+  if !debug then Format.eprintf "\nSaving to file %s\n" outfile_name ;
   let json = open_out outfile_name in
   Fun.protect ~finally:(fun () -> close_out json) (fun () -> f json)
 


### PR DESCRIPTION
This change adds an option `-o` (open to naming suggestions)
When specified, `compile_commands.json` is generated in that directory
This is useful where the IDE might be setup to look for the database in a specific directory.

Users can do something like `dune rules  | dune-compiledb -o /build/` rather than needing to do `dune rules  | dune-compiledb && cp ./compile_commands.json /build`